### PR TITLE
encodeURIComponent file name for a.href

### DIFF
--- a/themes/material/app.js
+++ b/themes/material/app.js
@@ -347,7 +347,7 @@ function append_files_to_list(path, files) {
 	            </a>
 	        </li>`;
     } else {
-      var p = path + item.name;
+      var p = path + encodeURIComponent(item.name);
       const filepath = path + item.name;
       var c = "file";
       // 当加载完最后一页后，才显示 README ，否则会影响滚动事件


### PR DESCRIPTION
如果文件名包含一些特殊字符比如`?`，那么直接将其拼接到url中访问会出问题，需要encodeURIComponent处理下。